### PR TITLE
表示の微調整

### DIFF
--- a/app/controllers/parking_lot_chart_controller.rb
+++ b/app/controllers/parking_lot_chart_controller.rb
@@ -55,8 +55,8 @@ class ParkingLotChartController < ApplicationController
                                           :select => :value,
                                           :conditions => ["customized_type = 'Version' AND custom_field_id = ? AND customized_id = ?", workday_setting, version.id]
                                           )
-        if !workday_name.nil? and !workday_value.nil?
-          data.workday = "#{workday_name.name}:#{workday_value.value} "
+        if !workday_name.nil? and !workday_value.nil? and !workday_value.value.empty?
+          data.workday = "#{workday_name.name}:#{workday_value.value}"
         end
       end
 
@@ -67,7 +67,7 @@ class ParkingLotChartController < ApplicationController
                                       :select => :value,
                                       :conditions => ["customized_type = 'Version' AND custom_field_id = ? AND customized_id = ?", day_setting, version.id]
                                       )
-        if !day_name.nil? and !day_value.nil?
+        if !day_name.nil? and !day_value.nil? and !day_value.value.empty?
           data.day = "#{day_name.name}:#{day_value.value}"
         end
       end

--- a/assets/stylesheets/parking_lot_chart.css
+++ b/assets/stylesheets/parking_lot_chart.css
@@ -1,7 +1,7 @@
 .versionbox {
   float: left;
   width: 120px;
-  height:100px;
+  height:110px;
   margin: 3px;
   padding: 2px;
   border: 1px solid #999999;
@@ -10,7 +10,7 @@
 .versionboxtitle {
   font-weight: bold;
   width: 100%;
-  height: 40px;
+  height: 50px;
   text-align: center;
   border-bottom: 1px solid #999999;
   overflow: auto;


### PR DESCRIPTION
カスタムフィールドの値がないときの表示を調整
タイトルが3行になった時にMacのChrome/FirefoxとWindowsのChrome/Firefoxの表示がそれなりに合うように調整
